### PR TITLE
Prevented a crash if you don't click in a slot.

### DIFF
--- a/Inventory.gd
+++ b/Inventory.gd
@@ -69,7 +69,10 @@ func _gui_input(event):
 			if isClicked:
 				clickedSlot = slot;
 		
-		if holdingItem != null:
+		if holdingItem == null and clickedSlot == null:
+			return
+			
+		if holdingItem != null and clickedSlot != null:
 			if clickedSlot.item != null:
 				var tempItem = clickedSlot.item;
 				var oldSlot = slotList[slotList.find(holdingItem.itemSlot)];


### PR DESCRIPTION
If you clicked in between slots or anywhere outside, it crashed because Godot apparently doesn't handle null checks well enough.