### PR TITLE
Casing error for the icon in the file project.godot

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -17,4 +17,4 @@ _global_script_class_icons={
 
 config/name="Inventory System Example"
 run/main_scene="res://Inventory.tscn"
-config/icon="res://icon.png"
+config/icon="res://Icon.png"


### PR DESCRIPTION
So i made a small mistake in the project.godot file:

Linux is case sensitive when it comes to handling files unlike Windows. I used the icon parameter from another template. I didn't notice the difference between the Icon.png file and the setting that was icon.png. Woops.

It doesn't break the project itself, it only prevents the project manager window to show the icon when opening Godot in Linux. I'm sending you a PR in case you care. If you don't just close it.